### PR TITLE
Revert "Bump numpy from 1.13.3 to 1.22.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ backports.functools-lru-cache==1.4
 cycler==0.10.0
 joblib==0.11
 matplotlib==2.1.0
-numpy==1.22.0
+numpy==1.13.3
 pyparsing==2.2.0
 python-dateutil==2.6.1
 pytz==2017.3


### PR DESCRIPTION
Reverts VeronicaToro/Signal-identifier#2